### PR TITLE
Adds start as a plugin method.

### DIFF
--- a/test/fixtures/plugin/magnet.config.js
+++ b/test/fixtures/plugin/magnet.config.js
@@ -1,0 +1,10 @@
+const myPlugin = require('./my-plugin');
+
+module.exports = {
+  magnet: {
+    port: 3000,
+    host: 'localhost',
+    logLevel: 'silent',
+    plugins: [myPlugin],
+  },
+};

--- a/test/fixtures/plugin/my-plugin.js
+++ b/test/fixtures/plugin/my-plugin.js
@@ -1,0 +1,5 @@
+export default {
+  start(magnet) {
+    magnet.__START_WAS_CALLED__ = true;
+  },
+};

--- a/test/fixtures/plugin/one.js
+++ b/test/fixtures/plugin/one.js
@@ -1,0 +1,8 @@
+/**
+ * @param {Magnet} app
+ */
+export const controller = function(app) {
+  app.get('/v1', (req, res) => {
+    res.json({foo: 'bar'});
+  });
+};

--- a/test/unit/magnet.js
+++ b/test/unit/magnet.js
@@ -250,4 +250,20 @@ describe('Magnet', () => {
       expect(magnet.getServer().getEngine().bootstrapValue).to.eq('finished');
     });
   });
+
+  describe('plugins', () => {
+    it('should call plugin\'s start method', async () => {
+      const directory = `${process.cwd()}/test/fixtures/plugin`;
+
+      const magnet = new Magnet({directory});
+      await magnet.build();
+
+      expect(magnet.__START_WAS_CALLED__).to.eq(undefined);
+
+      await magnet.start();
+      await magnet.stop();
+
+      expect(magnet.__START_WAS_CALLED__).to.eq(true);
+    });
+  });
 });


### PR DESCRIPTION
In addition, both objects and strings are allowed in the `plugins`
config array. The object follows the same api as the export of a
plugin module.