### PR TITLE
Improve CLI process lifecycle

### DIFF
--- a/src/bin/magnet
+++ b/src/bin/magnet
@@ -45,8 +45,9 @@ if (commands.has(cmd)) {
 }
 
 const bin = join(__dirname, 'magnet-' + cmd);
-let isWatcherInitialized = false;
+
 let childApp;
+let isWatcherInitialized = false;
 
 if (cmd === 'dev') {
   const watcher = chokidar.watch('**/*', {
@@ -56,14 +57,14 @@ if (cmd === 'dev') {
     ignoreInitial: true,
   });
 
-  watcher.on('change', restartApp);
   watcher.on('add', restartApp);
+  watcher.on('change', restartApp);
   watcher.on('unlink', restartApp);
 
   watcher.on('ready', () => {
     if (!isWatcherInitialized) {
+      startChildApp();
       isWatcherInitialized = true;
-      restartApp();
     }
   });
 
@@ -72,28 +73,19 @@ if (cmd === 'dev') {
     process.exit(1);
   });
 } else {
-  killApp();
-  spawnChildApp();
+  startChildApp();
 }
 
 /**
  * Restart current cli app.
  */
 function restartApp() {
-  if (!isWatcherInitialized) return;
-  prepareRestart();
-}
-
-/**
- * Prepares to restart.
- */
-function prepareRestart() {
-  if (isWatcherInitialized && childApp) {
-    // kill app early as `compile` may take a while
+  if (childApp) {
     log.info(false, 'Found a change, restarting the server…');
+    childApp.on('exit', () => startChildApp());
     killApp();
   } else {
-    spawnChildApp();
+    startChildApp();
   }
 }
 
@@ -101,24 +93,19 @@ function prepareRestart() {
  * Kills app.
  */
 function killApp() {
-  if (childApp) {
-    childApp.on('exit', () => {
-      spawnChildApp();
-    });
-    childApp.removeAllListeners('close');
-    try {
-      childApp.kill('SIGHUP');
-    } catch (error) {
-      childApp.kill('SIGKILL');
-    }
-    childApp = undefined;
+  childApp.removeAllListeners('close');
+  try {
+    childApp.kill('SIGHUP');
+  } catch (error) {
+    childApp.kill('SIGKILL');
   }
+  childApp = undefined;
 }
 
 /**
  * Spawns new child app.
  */
-function spawnChildApp() {
+function startChildApp() {
   childApp = spawn(
     bin, args,
     {stdio: 'inherit', customFds: [0, 1, 2]}

--- a/src/bin/magnet
+++ b/src/bin/magnet
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import {join} from 'path';
-import {spawn} from 'cross-spawn';
+import childProcess from 'child_process';
 import chokidar from 'chokidar';
 import log from '../log';
 import pkg from '../../package.json';
@@ -45,30 +45,8 @@ if (commands.has(cmd)) {
 }
 
 const bin = join(__dirname, 'magnet-' + cmd);
-
-const startProcess = () => {
-  const proc = spawn(bin, args, {stdio: 'inherit', customFds: [0, 1, 2]});
-  proc.on('close', (code, signal) => {
-    if (code !== null) {
-      process.exit(code);
-    }
-    if (signal) {
-      if (signal === 'SIGKILL') {
-        process.exit(137);
-      }
-      log.info(false, 'exitting');
-      process.exit(1);
-    }
-    process.exit(0);
-  });
-  proc.on('error', (err) => {
-    log.error(false, err);
-    process.exit(1);
-  });
-  return proc;
-};
-
-let proc = startProcess();
+let isWatcherInitialized = false;
+let childApp;
 
 if (cmd === 'dev') {
   const watcher = chokidar.watch('**/*', {
@@ -78,13 +56,88 @@ if (cmd === 'dev') {
     ignoreInitial: true,
   });
 
-  let restart = () => {
-    log.info(false, 'Found a change, restarting the server…');
-    proc.removeAllListeners('close');
-    proc.kill();
-    proc = startProcess();
-  };
+  watcher.on('change', restartApp);
+  watcher.on('add', restartApp);
+  watcher.on('unlink', restartApp);
 
-  watcher.on('change', restart);
-  watcher.on('unlink', restart);
+  watcher.on('ready', () => {
+    if (!isWatcherInitialized) {
+      isWatcherInitialized = true;
+      restartApp();
+    }
+  });
+
+  process.on('SIGINT', function() {
+    watcher.close();
+    process.exit(1);
+  });
+} else {
+  killApp();
+  spawnChildApp();
+}
+
+/**
+ * Restart current cli app.
+ */
+function restartApp() {
+  if (!isWatcherInitialized) return;
+  prepareRestart();
+}
+
+/**
+ * Prepares to restart.
+ */
+function prepareRestart() {
+  if (isWatcherInitialized && childApp) {
+    // kill app early as `compile` may take a while
+    log.info(false, 'Found a change, restarting the server…');
+    killApp();
+  } else {
+    spawnChildApp();
+  }
+}
+
+/**
+ * Kills app.
+ */
+function killApp() {
+  if (childApp) {
+    childApp.on('exit', () => {
+      spawnChildApp();
+    });
+    childApp.removeAllListeners('close');
+    try {
+      childApp.kill('SIGHUP');
+    } catch (error) {
+      childApp.kill('SIGKILL');
+    }
+    childApp = undefined;
+  }
+}
+
+/**
+ * Spawns new child app.
+ */
+function spawnChildApp() {
+  childApp = childProcess.fork(
+    bin, args,
+    {stdio: 'inherit', customFds: [0, 1, 2]}
+  );
+  childApp.on('close', (code, signal) => {
+    if (code !== null) {
+      process.exit(code);
+    }
+    if (signal) {
+      if (signal === 'SIGKILL') {
+        process.exit(137);
+      }
+      log.info(false, 'exiting');
+      process.exit(1);
+    }
+    process.exit(0);
+  });
+  childApp.on('error', (err) => {
+    log.error(false, err);
+    process.exit(1);
+  });
 }

--- a/src/bin/magnet
+++ b/src/bin/magnet
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 
 import {join} from 'path';
-import childProcess from 'child_process';
+import {spawn} from 'cross-spawn';
 import chokidar from 'chokidar';
 import log from '../log';
 import pkg from '../../package.json';
@@ -119,7 +119,7 @@ function killApp() {
  * Spawns new child app.
  */
 function spawnChildApp() {
-  childApp = childProcess.fork(
+  childApp = spawn(
     bin, args,
     {stdio: 'inherit', customFds: [0, 1, 2]}
   );

--- a/src/bin/magnet-build
+++ b/src/bin/magnet-build
@@ -2,6 +2,7 @@
 
 import {Magnet} from '../';
 import parseArgs from 'minimist';
+import log from '../log';
 
 const argv = parseArgs(process.argv.slice(2), {
   alias: {
@@ -31,4 +32,8 @@ const configDir = argv['config-dir'];
 const directory = process.cwd();
 const magnet = new Magnet({config, configDir, directory});
 
-magnet.build();
+magnet.build()
+  .catch((error) => {
+    log.error(null, error);
+    process.exit(1);
+  });

--- a/src/bin/magnet-dev
+++ b/src/bin/magnet-dev
@@ -7,6 +7,8 @@ import parseArgs from 'minimist';
 
 process.env.NODE_ENV = process.env.NODE_ENV || 'development';
 
+process.stdin.pause();
+
 const argv = parseArgs(process.argv.slice(2), {
   alias: {
     h: 'help',
@@ -42,12 +44,22 @@ magnet.build()
       log.infoNoPrefix(false, `\n${routes}\n`);
     }
   })
-  .then(() => magnet.start());
+  .then(() => magnet.start())
+  .catch((error) => {
+    if (error.code === 'EADDRINUSE') {
+      const errorMessage = `Port ${argv.port} is already in use.`;
+      log.error(false, errorMessage);
+    } else {
+      log.error(false, error);
+    }
+    process.nextTick(() => process.exit(1));
+  });
 
-process.on('SIGTERM', (err) => {
-  magnet.stop();
+process.on('SIGTERM', (error) => {
+  if (magnet) magnet.stop();
 });
 
-process.on('SIGINT', (err) => {
-  magnet.stop();
+process.on('SIGINT', (error) => {
+  if (magnet) magnet.stop();
+  process.nextTick(() => process.exit(1));
 });

--- a/src/bin/magnet-generate
+++ b/src/bin/magnet-generate
@@ -28,6 +28,9 @@ const dir = resolve(argv._[0] || '.');
 
 const basePackage = `{
   "name": "my-app",
+  "engines": {
+    "node": ">=7.6.0"
+  },
   "dependencies": {
     "magnet": "latest"
   },

--- a/src/bin/magnet-start
+++ b/src/bin/magnet-start
@@ -2,6 +2,7 @@
 
 import {Magnet} from '../';
 import parseArgs from 'minimist';
+import log from '../log';
 
 const argv = parseArgs(process.argv.slice(2), {
   alias: {
@@ -33,13 +34,17 @@ const configDir = argv['config-dir'];
 const directory = process.cwd();
 const magnet = new Magnet({config, configDir, directory});
 
-magnet.start();
+magnet.start()
+  .catch((error) => {
+    log.error(null, error);
+    process.exit(1);
+  });
 
-process.on('SIGTERM', (err) => {
+process.on('SIGTERM', (error) => {
   magnet.stop();
 });
 
-process.on('SIGINT', (err) => {
+process.on('SIGINT', (error) => {
   magnet.stop();
 });
 


### PR DESCRIPTION
It handles better the lifecycle of file watching in development mode and avoids the constant crashes with soy compilation.

- [x] applies refactoring on watcher lifecycle.
- [x] ensures it works with other CLI commands.
- [x] adds node version on project initialization.


With that change, I could not experience anymore the constant issues we have after saving files multiple times in a short amount of time.