### PR TITLE
LCP-1546 Add config parameter to overwrite global

### DIFF
--- a/src/build/server.js
+++ b/src/build/server.js
@@ -8,8 +8,6 @@ import {transformFileSync} from 'babel-core';
 
 const {JSDOM} = jsdom;
 const dom = new JSDOM();
-global.document = dom.window.document;
-global.window = dom.window;
 
 /**
  * Aggregate babel presets.
@@ -45,6 +43,12 @@ export async function buildServer(
   plugins = []
 ) {
   log.info(false, 'Building server…');
+
+  if (process.env.API_ONLY) {
+    global.document = dom.window.document;
+    global.window = dom.window;
+  }
+
   fs.removeSync(outputDirectory);
   const presets = aggregateBabelPresets(plugins);
 

--- a/src/config.js
+++ b/src/config.js
@@ -22,6 +22,7 @@ const baseConfig = () => {
       plugins: ['function', 'controller'],
       pluginsConfig: {},
       webpack: null,
+      apiOnly: false
     },
   };
 };

--- a/src/magnet.js
+++ b/src/magnet.js
@@ -82,6 +82,7 @@ class Magnet {
 
     this.registerWebpackConfig_();
     this.registerPlugins_();
+    this.registerProcessEvnVariables_(this.config);
   }
 
   /**
@@ -302,6 +303,14 @@ class Magnet {
         fn.call(this, app, this);
       }
     }
+  }
+
+  /**
+   * Register environment variables
+   * @param {Object} config 
+   */
+  registerProcessEvnVariables_(config) {
+    process.env.API_ONLY = config.magnet.apiOnly      
   }
 
   /**

--- a/test/fixtures/config/magnet.api.only.config.js
+++ b/test/fixtures/config/magnet.api.only.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+    magnet: {
+      port: 3000,
+      host: 'localhost',
+      logLevel: 'silent',
+      apiOnly: true,
+    },
+  };
+  

--- a/test/int/build/server.int.test.js
+++ b/test/int/build/server.int.test.js
@@ -1,4 +1,5 @@
 import {buildServer} from '../../../src/build/server';
+import {createConfig} from '../../../src/config';
 import fs from 'fs-extra';
 import Magnet from '../../../src/magnet';
 import path from 'path';
@@ -39,5 +40,24 @@ describe('.build', function() {
     expect(fs.existsSync(mockedFile)).toBeTruthy();
     await buildServer(magnet.getFiles({directory}), directory, serverDist);
     expect(fs.existsSync(mockedFile)).toBeFalsy();
+  });
+
+  test('set envrionment variable API_ONLY to true', async() => {
+    expect(process.env.API_ONLY).toBeUndefined();
+    const directory = `${process.cwd()}/test/fixtures/config`;
+    const config = 'magnet.api.only.config.js';
+    const magnet = new Magnet({config, directory});
+    await magnet.build();
+    expect(process.env.API_ONLY).toBeDefined();
+    expect(process.env.API_ONLY).toBeTruthy();
+  });
+  
+  test('do not set envrionment variable API_ONLY if is not on conifg', async() => {
+    expect(process.env.API_ONLY).toBeUndefined();
+    const directory = `${process.cwd()}/test/fixtures/config`;
+    const config = 'magnet.config.js';
+    const magnet = new Magnet({config, directory});
+    await magnet.build();
+    expect(process.env.API_ONLY).toBeUndefined();
   });
 });

--- a/test/int/build/server.int.test.js
+++ b/test/int/build/server.int.test.js
@@ -42,22 +42,21 @@ describe('.build', function() {
     expect(fs.existsSync(mockedFile)).toBeFalsy();
   });
 
-  test('set envrionment variable API_ONLY to true', async() => {
-    expect(process.env.API_ONLY).toBeUndefined();
+  test('set environment variable API_ONLY to true', async() => {
+    expect(process.env.API_ONLY).toBeFalsy();
     const directory = `${process.cwd()}/test/fixtures/config`;
     const config = 'magnet.api.only.config.js';
     const magnet = new Magnet({config, directory});
     await magnet.build();
-    expect(process.env.API_ONLY).toBeDefined();
     expect(process.env.API_ONLY).toBeTruthy();
   });
   
-  test('do not set envrionment variable API_ONLY if is not on conifg', async() => {
-    expect(process.env.API_ONLY).toBeUndefined();
+  test('do not set environment variable API_ONLY if is not on conifg', async() => {
+    expect(process.env.API_ONLY).toBeFalsy();
     const directory = `${process.cwd()}/test/fixtures/config`;
     const config = 'magnet.config.js';
     const magnet = new Magnet({config, directory});
     await magnet.build();
-    expect(process.env.API_ONLY).toBeUndefined();
+    expect(process.env.API_ONLY).toBeFalsy();
   });
 });


### PR DESCRIPTION
Context:
- Updating [API project](https://github.com/wedeploy/api) to Node 12 need to update some of the dependency modules. One of those is `@google-cloud/logging` and `@google-cloud/monitoring`.
They use a newer version of the `protobufjs` wich has a method to load google modules files: https://github.com/protobufjs/protobuf.js/blob/master/src/root.js#L234. This method check if the app is a node app on the following method: https://github.com/protobufjs/protobuf.js/blob/master/src/util/minimal.js#L55; which use the global window (https://github.com/protobufjs/protobuf.js/blob/master/src/util/minimal.js#L29) overwritten by Magnet.

This PR will require to API add a new config `apiOnly: true` so the global is not overwritten, but will let CONSOLE use it.